### PR TITLE
Always use the enum value for CLI defaults; fixes CLI for Click 8.2.0+

### DIFF
--- a/src/mlsimkit/common/cli.py
+++ b/src/mlsimkit/common/cli.py
@@ -1136,6 +1136,8 @@ class PydanticOptions:
             multiple = False
 
             if isclass(opt_type) and issubclass(opt_type, Enum):
+                if default is not None and isinstance(default, Enum):
+                    default = default.value # work-around Click 8.2.0 breaking change
                 opt_type = click.Choice([e.name if cli.use_enum_name else e.value for e in opt_type])
             elif issubclass(_GenericAlias, type(opt_type)):
                 if issubclass(list, get_origin(opt_type)):


### PR DESCRIPTION
*Issue:* https://github.com/awslabs/ai-surrogate-models-in-engineering-on-aws/issues/1

*Description of changes:*

Our CLI framework [automatically](https://github.com/awslabs/ai-surrogate-models-in-engineering-on-aws/blob/main/src/mlsimkit/common/cli.py#L1138-L1139) turns Enums into Click.Choice options.  Enums with a default value started breaking due to a breaking change introduced by Click 8.2.0, see https://github.com/pallets/click/issues/2911.

For example, the enum below sets a default value: 
```
    mapping_interpolation_method: InterpolationMethod = Field(
        default=InterpolationMethod.POINTS, 
        description="the interpolation method to be used for mapping")
```        

The CLI framework now use the enum value rather than rely on Click.Option implicitly. Using the enum value still works even when the enum name differs to the string value because our CLI internally always accepts the value as input, not the name. 

*Testing*

Relying on the default: 
```
(.venv) $ mlsimkit-learn --output-dir quickstart/surface     --config src/mlsimkit/conf/surface/sample.yaml     surface preprocess
[INFO] [MLSimKit] Learning Tools
[INFO] Package Version: 0.1.dev7+g4768e1e
[INFO] Use Case: Surface variable prediction via MeshGraphNets (MGN)
[INFO] Running command 'preprocess'
[INFO] Preprocessing configuration: 
[INFO] Total preprocessing time: 1.027 seconds
[INFO] Splitting manifest into train-size=0.6 valid-size=0.2 test-size=0.2
...
(.venv) $ python --version
Python 3.12.3
(.venv) $ python -c "import importlib.metadata; print(importlib.metadata.version('click'))"
8.2.0

```

And specifying an enum value as an option:
```
(.venv) $ mlsimkit-learn --output-dir quickstart/surface  --config src/mlsimkit/conf/surface/sample.yaml   surface preprocess --mapping-interpolation-method radius
[INFO] [MLSimKit] Learning Tools
[INFO] Package Version: 0.1.dev7+g4768e1e
[INFO] Use Case: Surface variable prediction via MeshGraphNets (MGN)
[INFO] Running command 'preprocess'
...
[INFO] Preprocessing configuration: downsample_remaining_perc=None num_processes=None save_cell_data=True map_data_to_stl=False mapping_interpolation_method=<InterpolationMethod.RADIUS: 'radius'> mapping_interpolation_radius=None mapping_interpolation_n_points=3 save_mapped_files=False normalize_node_positions=True manifest_base_relative_path=<RelativePathBase.ManifestRoot: 'ManifestRoot'>
[INFO] Using 'data_files' for preprocessing
...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
